### PR TITLE
 Fix xUnit.net assertion parameters

### DIFF
--- a/ChainingAssertion.xUnit/ChainingAssertion.xUnit.cs
+++ b/ChainingAssertion.xUnit/ChainingAssertion.xUnit.cs
@@ -141,8 +141,8 @@ namespace Xunit
             if (typeof(T) != typeof(string) && typeof(IEnumerable).IsAssignableFrom(typeof(T)))
             {
                 Assert.Equal(
-                    ((IEnumerable)actual).Cast<object>().ToArray(),
-                    ((IEnumerable)expected).Cast<object>().ToArray());
+                    ((IEnumerable)expected).Cast<object>().ToArray(),
+                    ((IEnumerable)actual).Cast<object>().ToArray());
                 return;
             }
 


### PR DESCRIPTION
Fix xUnit.net assertion parameters for Assert.Equal<T>(T expected, T actual)
