### PR TITLE
Fix 'code is unreachable'

### DIFF
--- a/ChainingAssertion/ChainingAssertion.MSTest.cs
+++ b/ChainingAssertion/ChainingAssertion.MSTest.cs
@@ -643,7 +643,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
                     typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] { value }).ToArray());
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); }
             }
 
             public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
@@ -653,7 +653,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
                     result = typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.GetProperty, null, target, indexes);
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); }
             }
 
             public override bool TrySetMember(SetMemberBinder binder, object value)


### PR DESCRIPTION
Because semicolon after catch is not needed