### PR TITLE
Remove unneeded semicolon after catch

### DIFF
--- a/ChainingAssertion.NUnit/ChainingAssertion.NUnit.cs
+++ b/ChainingAssertion.NUnit/ChainingAssertion.NUnit.cs
@@ -495,10 +495,13 @@ namespace NUnit.Framework
             {
                 try
                 {
-                    typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] { value }).ToArray());
+                    typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] {value}).ToArray());
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException)
+                {
+                    throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name));
+                }
             }
 
             public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
@@ -508,7 +511,10 @@ namespace NUnit.Framework
                     result = typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.GetProperty, null, target, indexes);
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException)
+                {
+                    throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name));
+                }
             }
 
             public override bool TrySetMember(SetMemberBinder binder, object value)

--- a/ChainingAssertion.xUnit/ChainingAssertion.xUnit.cs
+++ b/ChainingAssertion.xUnit/ChainingAssertion.xUnit.cs
@@ -519,10 +519,13 @@ namespace Xunit
             {
                 try
                 {
-                    typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] { value }).ToArray());
+                    typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] {value}).ToArray());
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException)
+                {
+                    throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name));
+                }
             }
 
             public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
@@ -532,7 +535,10 @@ namespace Xunit
                     result = typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.GetProperty, null, target, indexes);
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException)
+                {
+                    throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name));
+                }
             }
 
             public override bool TrySetMember(SetMemberBinder binder, object value)

--- a/ChainingAssertion/ChainingAssertion.MSTest.cs
+++ b/ChainingAssertion/ChainingAssertion.MSTest.cs
@@ -640,10 +640,13 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             {
                 try
                 {
-                    typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] { value }).ToArray());
+                    typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.SetProperty, null, target, indexes.Concat(new[] {value}).ToArray());
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException)
+                {
+                    throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name));
+                }
             }
 
             public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
@@ -653,7 +656,10 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
                     result = typeof(T).InvokeMember("Item", TransparentFlags | BindingFlags.GetProperty, null, target, indexes);
                     return true;
                 }
-                catch (MissingMethodException) { throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name)); };
+                catch (MissingMethodException)
+                {
+                    throw new ArgumentException(string.Format("indexer not found : Type <{0}>", typeof(T).Name));
+                }
             }
 
             public override bool TrySetMember(SetMemberBinder binder, object value)


### PR DESCRIPTION
Semicolon after catch is not needed. This PR removes them with slight reformatting.

Issue 'Code is unreachable' comes from JetBrains ReSharper which begins to highlight different issues after installing ChainingAssertion NuGet package. It would be good to reduce such 'noise' from files which one does not own.