### PR TITLE
Use equality operator instead of Equals

### DIFF
--- a/ChainingAssertion.NUnit/ChainingAssertion.NUnit.cs
+++ b/ChainingAssertion.NUnit/ChainingAssertion.NUnit.cs
@@ -618,7 +618,7 @@ namespace NUnit.Framework
                         .SequenceEqual(parameterTypes, new EqualsComparer<Type>((x, y) =>
                             (x.IsGenericParameter)
                                 ? a.TypeParameters[x].IsAssignableFrom(y)
-                                : x.Equals(y)))
+                                : x == y))
                     )
                     .ToArray();
 

--- a/ChainingAssertion.xUnit/ChainingAssertion.xUnit.cs
+++ b/ChainingAssertion.xUnit/ChainingAssertion.xUnit.cs
@@ -642,7 +642,7 @@ namespace Xunit
                         .SequenceEqual(parameterTypes, new EqualsComparer<Type>((x, y) =>
                             (x.IsGenericParameter)
                                 ? a.TypeParameters[x].IsAssignableFrom(y)
-                                : x.Equals(y)))
+                                : x == y))
                     )
                     .ToArray();
 

--- a/ChainingAssertion/ChainingAssertion.MSTest.cs
+++ b/ChainingAssertion/ChainingAssertion.MSTest.cs
@@ -371,7 +371,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         {
             var exception = Catch<T>(testCode, message);
 
-            if (!typeof(T).Equals(exception.GetType()))
+            if (typeof(T) != exception.GetType())
             {
                 var headerMsg = "Failed Throws<" + typeof(T).Name + ">.";
                 var additionalMsg = string.IsNullOrEmpty(message) ? "" : ", " + message;
@@ -763,7 +763,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
                         .SequenceEqual(parameterTypes, new EqualsComparer<Type>((x, y) =>
                             (x.IsGenericParameter)
                                 ? a.TypeParameters[x].IsAssignableFrom(y)
-                                : x.Equals(y)))
+                                : x == y))
                     )
                     .ToArray();
 


### PR DESCRIPTION
Since Type is a singleton it is better to use ==/!= to compare instances of System.Type