### PR TITLE
Fix string comparison in DynamicTest(s)

### DIFF
--- a/ChainingAssertion.NUnit/UnitTest.NUnit.cs
+++ b/ChainingAssertion.NUnit/UnitTest.NUnit.cs
@@ -181,7 +181,7 @@ namespace ChainingAssertion
             d[3] = 'A';
             (d.privateField as string).Is("AAA");
 
-            ((string)d[100.101]).Is("100.101");
+            ((string)d[100.101]).Is(100.101.ToString());
             d[72] = "Chihaya";
             (d.privateField as string).Is("Chihaya72");
 

--- a/ChainingAssertion.xUnit/UnitTest.xUnit.cs
+++ b/ChainingAssertion.xUnit/UnitTest.xUnit.cs
@@ -184,7 +184,7 @@ namespace ChainingAssertion
             d[3] = 'A';
             (d.privateField as string).Is("AAA");
 
-            ((string)d[100.101]).Is("100.101");
+            ((string)d[100.101]).Is(100.101.ToString());
             d[72] = "Chihaya";
             (d.privateField as string).Is("Chihaya72");
 

--- a/ChainingAssertion/UnitTest.MSTest.cs
+++ b/ChainingAssertion/UnitTest.MSTest.cs
@@ -194,7 +194,7 @@ namespace ChainingAssertion
             d[3] = 'A';
             (d.privateField as string).Is("AAA");
 
-            ((string)d[100.101]).Is("100.101");
+            ((string)d[100.101]).Is(100.101.ToString());
             d[72] = "Chihaya";
             (d.privateField as string).Is("Chihaya72");
 


### PR DESCRIPTION
DynamicTest compares two string with implied assumption about decimal separator being a '.' which is not true for all cultures. And thus test fails when this assumption is wrong. I think it can be fixed by calling to .ToString() method on double value which will use current CultureInfo and tests will pass.